### PR TITLE
Ignore tags in lint-build workflow

### DIFF
--- a/.github/workflows/lint-build.yml
+++ b/.github/workflows/lint-build.yml
@@ -3,6 +3,8 @@ name: Lint Builds
   push:
     branches:
       - '*'
+    tags-ignore:
+      - '**'
   workflow_dispatch: ~
 jobs:
   build-native:


### PR DESCRIPTION
From the comment [here](https://github.com/orgs/community/discussions/25615#discussioncomment-3248479). Hopefully fixes #7.