### PR TITLE
Fix color distribution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file. See [Keep a
 
 ## Unreleased
 
+### Changed
+
+- Changed the way new colors are generated for the web interface.
+
 ## [1.7.0] - 2024-01-23
 
 ### Changed

--- a/wasm/.eslintrc.yml
+++ b/wasm/.eslintrc.yml
@@ -15,7 +15,6 @@ rules:
   '@typescript-eslint/ban-ts-comment':
     - error
     - ts-nocheck: false
-  '@typescript-eslint/class-methods-use-this': error
   '@typescript-eslint/consistent-type-imports': error
   '@typescript-eslint/default-param-last': error
   '@typescript-eslint/no-non-null-assertion': 'off'

--- a/wasm/Colors.civet
+++ b/wasm/Colors.civet
@@ -88,4 +88,67 @@ class Colors
 
   [Symbol.toStringTag] = 'Colors'
 
+  randomColor()
+    interface Luv
+      L: number
+      u: number
+      v: number
+
+    // #ff0000, #00ff00, and #0000ff in CIELUV space
+    RED := { L: 53.2328818, u: 172.93531, v: 42.8274281 } as const satisfies Luv
+    GREEN := { L: 87.7370335, u: -86.5701309, v: 115.769016 } as const satisfies Luv
+    BLUE := { L: 32.3025867, u: -10.6849381, v: -127.277647 } as const satisfies Luv
+
+    // Gamma correction constant
+    INV_GAMMA := 0.416666667 as const
+
+    RED_ANGLE := Math.atan2 RED.v, RED.u
+    GREEN_ANGLE := Math.atan2 GREEN.v, GREEN.u
+    BLUE_ANGLE := Math.atan2 BLUE.v, BLUE.u
+
+    // Select a random hue and saturation
+    hueAngle := 2 * Math.PI * (Math.random() - 0.5)
+    relativeSat := Math.sqrt Math.random()
+
+    // find the point on the edge of the RGB triangle with the selected hue
+    let p1: Luv, p2: Luv
+    if RED_ANGLE <= hueAngle < GREEN_ANGLE
+      p1 = RED
+      p2 = GREEN
+    else if BLUE_ANGLE <= hueAngle < RED_ANGLE
+      p1 = BLUE
+      p2 = RED
+    else
+      p1 = GREEN
+      p2 = BLUE
+    slope := (p2.v - p1.v) / (p2.u - p1.u)
+    u .= (p1.u * slope - p1.v) / (slope - Math.tan hueAngle)
+    v .= slope * (u - p1.u) + p1.v
+    // Given v*, interpolate L* between the corners
+    shiftAmount := (v - p2.v) / (p1.v - p2.v)
+    L .= p1.L * shiftAmount + p2.L * (1 - shiftAmount)
+
+    // Scale u* and v* by the saturation
+    u *= relativeSat
+    v *= relativeSat
+    // Scale L*, but centered at 50 rather than 0
+    L = (L - 50) * relativeSat + 50
+
+    // Convert from L*u*v* to XYZ
+    uPrime := u / (13 * L) + 0.2009
+    vPrime := v / (13 * L) + 0.461
+    Y := ((L + 16) / 116) ** 3
+    X := Y * 9 * uPrime / (4 * vPrime)
+    Z := Y * (12 - 3 * uPrime - 20 * vPrime) / (4 * vPrime)
+
+    // Convert XYZ to linear RGB
+    linR := 3.2406 * X - 1.5372 * Y - 0.4986 * Z
+    linG := -0.9689 * X + 1.8758 * Y + 0.0415 * Z
+    linB := 0.0557 * X - 0.204 * Y + 1.057 * Z
+
+    // Gamma-compress
+    R: Math.round 255 * linR ** INV_GAMMA || 0
+    G: Math.round 255 * linG ** INV_GAMMA || 0
+    B: Math.round 255 * linB ** INV_GAMMA || 0
+
 export type { Colors }

--- a/wasm/build_wasm.sh
+++ b/wasm/build_wasm.sh
@@ -40,7 +40,7 @@ case "$1" in
 
         civet --js -c in.civet -o - | terser -c unsafe=true,unsafe_arrows=true -mo index.js --ecma 13 \
             -f wrap_func_args=false
-        civet --js -c Colors.civet -o - | terser -cmf wrap_func_args=false -o Colors.js --ecma 13
+        civet --js -c Colors.civet -o - | terser -c unsafe_math=true -mf wrap_func_args=false -o Colors.js --ecma 13
         sass in.scss:index.css lowdata.scss:lowdata.css --no-source-map -s compressed
 
         wait -n

--- a/wasm/build_wasm.sh
+++ b/wasm/build_wasm.sh
@@ -40,7 +40,7 @@ case "$1" in
 
         civet --js -c in.civet -o - | terser -c unsafe=true,unsafe_arrows=true -mo index.js --ecma 13 \
             -f wrap_func_args=false
-        civet --js -c Colors.civet -o - | terser -c unsafe_math=true -mf wrap_func_args=false -o Colors.js --ecma 13
+        civet --js -c Colors.civet -o - | terser -cmf wrap_func_args=false -o Colors.js --ecma 13
         sass in.scss:index.css lowdata.scss:lowdata.css --no-source-map -s compressed
 
         wait -n

--- a/wasm/in.civet
+++ b/wasm/in.civet
@@ -363,10 +363,8 @@ updateColorPicker := :void =>
       :void ->
         let color: string
         loop
-          red := Math.round 255 * Math.random()
-          green := Math.round 255 * Math.random()
-          blue := Math.round 255 * Math.random()
-          color = `rgb(${red}, ${green}, ${blue})`
+          { R, G, B } := colors.randomColor()
+          color = `rgb(${R}, ${G}, ${B})`
           break if colors.addColor color
         elements.colorPicker.insertBefore createColorDiv(color, colors.count() - 1), @
       { +passive }


### PR DESCRIPTION
Rather than generating independently random R, G, and B, this generates the hue and chromaticity within CIE LCh color space, and then converts that to CIELUV -> CIEXYZ -> linear RGB -> sRGB. This makes the color look more uniform, but it has one downside: because sRGB is a triangle in CIE color space, the C* must be expressed as a saturation relative to what sRGB is capable of representing, rather than a true chromaticity. L* is determined by interpolation rather than generated outright.